### PR TITLE
Add shrink method.

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -111,6 +111,14 @@ impl<T, V> Cache<T, V> {
     pub async fn clear(&self) {
         self.items.write().await.clear()
     }
+
+    /// Reclaim memory from removed / cleared items
+    pub async fn shrink(&self)
+    where
+        T: Eq + Hash,
+    {
+        self.items.write().await.shrink_to_fit()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I needed the ability to shrink memory after purging or expiring many items to conserve memory and monitor how much I am using in my particular application over time. HashMap will leave memory allocated for future use, forever it appears, which is not ideal for me.