### PR TITLE
use dashmap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r-cache"
-version = "0.4.5"
+version = "0.5.0"
 authors = ["cobbinma <cobbinma@gmail.com>"]
 edition = "2021"
 description = "r-cache is an in memory key value store. It is thread safe and values have expiry times"
@@ -9,14 +9,13 @@ readme = "README.md"
 repository = "https://github.com/cobbinma/r-cache"
 categories = [
     "caching",
-    "asynchronous"
 ]
-keywords = ["cache", "async"]
+keywords = ["cache"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-lock = "2.4.0"
+dashmap = "5.4"
 
 [dev-dependencies]
 async-std = { version = "1.10.0", features = ["attributes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ keywords = ["cache"]
 dashmap = "5.4"
 
 [dev-dependencies]
-async-std = { version = "1.10.0", features = ["attributes"] }
+async-std = { version = "1.12", features = ["attributes"] }

--- a/Readme.md
+++ b/Readme.md
@@ -48,13 +48,13 @@ async fn main() {
         async move {
             loop {
                 task::sleep(Duration::from_secs(10 * 60)).await;
-                cache.remove_expired().await;
+                cache.remove_expired();
             }
         }
     });
 
-    cache.set(KEY, VALUE, None).await;
+    cache.set(KEY, VALUE, None);
 
-    assert_eq!(VALUE, cache.get(&KEY).await.unwrap())
+    assert_eq!(VALUE, cache.get(&KEY).unwrap())
 }
 ```

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,16 +1,19 @@
-use async_lock::RwLock;
-use std::collections::HashMap;
+use dashmap::DashMap;
 
 use crate::item::Item;
 use std::hash::Hash;
 use std::time::Duration;
 
 pub struct Cache<T, V> {
-    items: RwLock<HashMap<T, Item<V>>>,
+    items: DashMap<T, Item<V>>,
     item_duration: Option<Duration>,
 }
 
-impl<T, V> Cache<T, V> {
+impl<T, V> Cache<T, V>
+where
+    T: Eq + Hash,
+    V: Clone,
+{
     /// Construct a new `Cache` with a default item expiration time.
     /// An item duration of `None` means items do not expire by default.
     ///
@@ -33,32 +36,30 @@ impl<T, V> Cache<T, V> {
     ///         async move {
     ///             loop {
     ///                 task::sleep(Duration::from_secs(10 * 60)).await;
-    ///                 cache.remove_expired().await;
+    ///                 cache.remove_expired();
     ///             }
     ///         }
     ///     });
     ///
-    ///     cache.set(KEY, VALUE, None).await;
+    ///     cache.set(KEY, VALUE, None);
     ///
-    ///     assert_eq!(VALUE, cache.get(&KEY).await.unwrap())
+    ///     assert_eq!(VALUE, cache.get(&KEY).unwrap())
     /// }
     /// ```
     pub fn new(item_duration: Option<Duration>) -> Self {
         Cache {
-            items: RwLock::new(HashMap::new()),
+            items: DashMap::new(),
             item_duration,
         }
     }
 
     /// Get a cache item associated with a given key.
-    pub async fn get(&self, key: &T) -> Option<V>
+    pub fn get(&self, key: &T) -> Option<V>
     where
         T: Eq + Hash,
         V: Clone,
     {
         self.items
-            .read()
-            .await
             .get(key)
             .filter(|item| !item.expired())
             .map(|item| item.object.clone())
@@ -66,13 +67,11 @@ impl<T, V> Cache<T, V> {
 
     /// Set an item in the cache with an associated key.
     /// The item will have the default cache expiration time if custom duration of `None` is given.
-    pub async fn set(&self, key: T, value: V, custom_duration: Option<Duration>) -> Option<V>
+    pub fn set(&self, key: T, value: V, custom_duration: Option<Duration>) -> Option<V>
     where
         T: Eq + Hash,
     {
         self.items
-            .write()
-            .await
             .insert(
                 key,
                 Item::new(value, custom_duration.or(self.item_duration)),
@@ -81,43 +80,37 @@ impl<T, V> Cache<T, V> {
     }
 
     /// Remove all expired items from the cache.
-    pub async fn remove_expired(&self)
+    pub fn remove_expired(&self)
     where
         T: Eq + Hash + Clone,
     {
-        let expired_keys = self
-            .items
-            .read()
-            .await
-            .iter()
-            .filter(|(_, item)| item.expired())
-            .map(|(k, _)| k.clone())
-            .collect::<Vec<T>>();
-
-        for key in expired_keys {
-            self.items.write().await.remove(&key);
-        }
+        self.items.retain(|_, item| !item.expired());
+        self.shrink();
     }
 
     /// Remove an item from the cache associated with a given key.
-    pub async fn remove(&self, key: &T) -> Option<V>
+    pub fn remove(&self, key: &T) -> Option<V>
     where
         T: Eq + Hash,
     {
-        self.items.write().await.remove(key).map(|item| item.object)
+        let item = self.items.remove(key).map(|(_, item)| item.object);
+        self.shrink();
+
+        item
     }
 
     /// Clear the entire cache of all items regardless of expiry times.
-    pub async fn clear(&self) {
-        self.items.write().await.clear()
+    pub fn clear(&self) {
+        self.items.clear();
+        self.shrink();
     }
 
     /// Reclaim memory from removed / cleared items
-    pub async fn shrink(&self)
+    pub fn shrink(&self)
     where
         T: Eq + Hash,
     {
-        self.items.write().await.shrink_to_fit()
+        self.items.shrink_to_fit()
     }
 }
 
@@ -129,108 +122,108 @@ mod tests {
     const KEY: i8 = 0;
     const VALUE: &str = "VALUE";
 
-    #[async_std::test]
-    async fn set_and_get_value_with_default_duration() {
+    #[test]
+    fn set_and_get_value_with_default_duration() {
         let cache = Cache::new(Some(Duration::from_secs(2)));
-        cache.set(KEY, VALUE, None).await;
-        let value = cache.get(&KEY).await;
+        cache.set(KEY, VALUE, None);
+        let value = cache.get(&KEY);
         match value {
             Some(value) => assert_eq!(value, VALUE),
             None => panic!("value was not found in cache"),
         };
     }
 
-    #[async_std::test]
-    async fn set_and_get_value_without_duration() {
+    #[test]
+    fn set_and_get_value_without_duration() {
         let cache = Cache::new(None);
-        cache.set(KEY, VALUE, None).await;
-        let value = cache.get(&KEY).await;
+        cache.set(KEY, VALUE, None);
+        let value = cache.get(&KEY);
         match value {
             Some(value) => assert_eq!(value, VALUE),
             None => panic!("value was not found in cache"),
         };
     }
 
-    #[async_std::test]
-    async fn set_and_get_value_with_custom_duration() {
+    #[test]
+    fn set_and_get_value_with_custom_duration() {
         let cache = Cache::new(Some(Duration::from_secs(0)));
-        cache.set(KEY, VALUE, Some(Duration::from_secs(2))).await;
-        let value = cache.get(&KEY).await;
+        cache.set(KEY, VALUE, Some(Duration::from_secs(2)));
+        let value = cache.get(&KEY);
         match value {
             Some(value) => assert_eq!(value, VALUE),
             None => panic!("value was not found in cache"),
         };
     }
 
-    #[async_std::test]
-    async fn set_do_not_get_expired_value() {
+    #[test]
+    fn set_do_not_get_expired_value() {
         let cache = Cache::new(Some(Duration::from_secs(0)));
-        cache.set(KEY, VALUE, None).await;
-        let value = cache.get(&KEY).await;
+        cache.set(KEY, VALUE, None);
+        let value = cache.get(&KEY);
         if value.is_some() {
             panic!("found expired value in cache")
         };
     }
 
-    #[async_std::test]
-    async fn set_replace_existing_value() {
+    #[test]
+    fn set_replace_existing_value() {
         const NEW_VALUE: &str = "NEW_VALUE";
         let cache = Cache::new(Some(Duration::from_secs(2)));
-        cache.set(KEY, VALUE, None).await;
-        cache.set(KEY, NEW_VALUE, None).await;
-        let value = cache.get(&KEY).await;
+        cache.set(KEY, VALUE, None);
+        cache.set(KEY, NEW_VALUE, None);
+        let value = cache.get(&KEY);
         match value {
             Some(value) => assert_eq!(value, NEW_VALUE),
             None => panic!("value was not found in cache"),
         };
     }
 
-    #[async_std::test]
-    async fn remove_expired_item() {
+    #[test]
+    fn remove_expired_item() {
         let cache = Cache::new(Some(Duration::from_secs(0)));
-        cache.set(KEY, VALUE, None).await;
-        cache.remove_expired().await;
-        if cache.items.read().await.get(&KEY).is_some() {
+        cache.set(KEY, VALUE, None);
+        cache.remove_expired();
+        if cache.items.get(&KEY).is_some() {
             panic!("found expired item in cache")
         };
     }
 
-    #[async_std::test]
-    async fn remove_expired_do_not_remove_not_expired_item() {
+    #[test]
+    fn remove_expired_do_not_remove_not_expired_item() {
         let cache = Cache::new(Some(Duration::from_secs(2)));
-        cache.set(KEY, VALUE, None).await;
-        cache.remove_expired().await;
-        if cache.items.read().await.get(&KEY).is_none() {
+        cache.set(KEY, VALUE, None);
+        cache.remove_expired();
+        if cache.items.get(&KEY).is_none() {
             panic!("could not find not expired item in cache")
         };
     }
 
-    #[async_std::test]
-    async fn clear_not_expired_item() {
+    #[test]
+    fn clear_not_expired_item() {
         let cache = Cache::new(Some(Duration::from_secs(2)));
-        cache.set(KEY, VALUE, None).await;
-        cache.clear().await;
-        if cache.items.read().await.get(&KEY).is_some() {
+        cache.set(KEY, VALUE, None);
+        cache.clear();
+        if cache.items.get(&KEY).is_some() {
             panic!("found item in cache")
         };
     }
 
-    #[async_std::test]
-    async fn remove_remove_expired_item() {
+    #[test]
+    fn remove_remove_expired_item() {
         let cache = Cache::new(Some(Duration::from_secs(2)));
-        cache.set(KEY, VALUE, None).await;
-        if let None = cache.remove(&KEY).await {
+        cache.set(KEY, VALUE, None);
+        if let None = cache.remove(&KEY) {
             panic!("none returned from removing existing value")
         };
-        if cache.items.read().await.get(&KEY).is_some() {
+        if cache.items.get(&KEY).is_some() {
             panic!("found not expired item in cache")
         };
     }
 
-    #[async_std::test]
-    async fn remove_return_none_if_not_found() {
+    #[test]
+    fn remove_return_none_if_not_found() {
         let cache: Cache<i8, &str> = Cache::new(Some(Duration::from_secs(2)));
-        if let Some(_) = cache.remove(&KEY).await {
+        if let Some(_) = cache.remove(&KEY) {
             panic!("some value was returned from remove")
         };
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,9 @@
 //! # #[async_std::main]
 //! # async fn main() {
 //!    let cache = Cache::new(Some(Duration::from_secs(2 * 60 * 60)));
-//!    cache.set(KEY, VALUE, None).await;
+//!    cache.set(KEY, VALUE, None);
 //!
-//!    println!("{}", cache.get(&KEY).await.unwrap())
+//!    println!("{}", cache.get(&KEY).unwrap())
 //! }
 //! ```
 


### PR DESCRIPTION
Change the `items` data structure to use [dashmap](https://crates.io/crates/dashmap).

This will remove the need for a `RWLock` when accessing items.

When using any remove functions, `r-cache` will now resize the map by default.

![](https://media.giphy.com/media/cjbfyJrICOaKIXBWyG/giphy.gif)